### PR TITLE
GL_WRAP_BORDER can not be used w/ glTexParameteri

### DIFF
--- a/assignment3/Mesh/mesh.h
+++ b/assignment3/Mesh/mesh.h
@@ -81,8 +81,8 @@ public:
         glBindTexture(GL_TEXTURE_2D, _diffuse_tex);
 
         check_error_gl();
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_WRAP_BORDER);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_WRAP_BORDER);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
         check_error_gl();


### PR DESCRIPTION
Changed it to use the default value instead, `GL_REPEAT`. See the [reference](https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glTexParameter.xhtml).